### PR TITLE
Cache open data

### DIFF
--- a/lib/Models/repositories/somministrazione_vaccini_latest.dart
+++ b/lib/Models/repositories/somministrazione_vaccini_latest.dart
@@ -1,4 +1,6 @@
 import 'dart:convert' as convert;
+import 'package:statusvaccini/Models/opendata.dart';
+import 'package:statusvaccini/cache/cache.dart';
 import 'package:statusvaccini/constants/url_constant.dart';
 import 'package:http/http.dart' as http;
 
@@ -42,34 +44,40 @@ class SomministrazioneVacciniLatest {
       this.nome_regione});
 
   static Future<List<SomministrazioneVacciniLatest>> getListData() async {
-    var response =
-        await http.get(Uri.parse(URLConst.somministrazioneVacciniLatest));
+    String data;
+    var cache = Cache<SomministrazioneVacciniLatest>();
+    if (!(await cache.needsUpdate())) {
+      data = await cache.getData();
+    } else {
+      var latestUpdate = await OpenData.getLastUpdateData();
+      data = await http.read(Uri.parse(URLConst.somministrazioneVacciniLatest));
+      cache.update(latestUpdate, data);
+    }
+
     List<SomministrazioneVacciniLatest> list = [];
 
-    if (response.statusCode == 200) {
-      var jsonResponse = convert.jsonDecode(response.body);
-      var jsonData = jsonResponse['data'];
+    var jsonResponse = convert.jsonDecode(data);
+    var jsonData = jsonResponse['data'];
 
-      for (var element in jsonData) {
-        list.add(new SomministrazioneVacciniLatest(
-          index: element['index'],
-          area: element['area'],
-          fornitore: element['fornitore'],
-          data_somministrazione: element['data_somministrazione'],
-          fascia_anagrafica: element['fascia_anagrafica'],
-          sesso_maschile: element['sesso_maschile'],
-          sesso_femminile: element['sesso_femminile'],
-          categoria_operatori_sanitari_sociosanitari:
-              element['categoria_operatori_sanitari_sociosanitari'],
-          categoria_personale_non_sanitario:
-              element['categoria_personale_non_sanitario'],
-          categoria_ospiti_rsa: element['categoria_ospiti_rsa'],
-          categoria_over80: element['categoria_over80'],
-          prima_dose: element['prima_dose'],
-          seconda_dose: element['seconda_dose'],
-          nome_regione: element['nome_area'],
-        ));
-      }
+    for (var element in jsonData) {
+      list.add(new SomministrazioneVacciniLatest(
+        index: element['index'],
+        area: element['area'],
+        fornitore: element['fornitore'],
+        data_somministrazione: element['data_somministrazione'],
+        fascia_anagrafica: element['fascia_anagrafica'],
+        sesso_maschile: element['sesso_maschile'],
+        sesso_femminile: element['sesso_femminile'],
+        categoria_operatori_sanitari_sociosanitari:
+            element['categoria_operatori_sanitari_sociosanitari'],
+        categoria_personale_non_sanitario:
+            element['categoria_personale_non_sanitario'],
+        categoria_ospiti_rsa: element['categoria_ospiti_rsa'],
+        categoria_over80: element['categoria_over80'],
+        prima_dose: element['prima_dose'],
+        seconda_dose: element['seconda_dose'],
+        nome_regione: element['nome_area'],
+      ));
     }
     return list;
   }

--- a/lib/Models/repositories/somministrazione_vaccini_summary_latest.dart
+++ b/lib/Models/repositories/somministrazione_vaccini_summary_latest.dart
@@ -1,6 +1,8 @@
 import 'dart:convert' as convert;
+import 'package:statusvaccini/Models/opendata.dart';
 import 'package:statusvaccini/constants/url_constant.dart';
 import 'package:http/http.dart' as http;
+import 'package:statusvaccini/cache/cache.dart';
 
 // ignore_for_file: non_constant_identifier_names
 
@@ -42,33 +44,40 @@ class SomministrazioneVacciniSummaryLatest {
 
   static Future<List<SomministrazioneVacciniSummaryLatest>>
       getListData() async {
-    var response = await http
-        .get(Uri.parse(URLConst.somministrazioneVacciniSummaryLatest));
+    String data;
+    var cache = Cache<SomministrazioneVacciniSummaryLatest>();
+    if (!(await cache.needsUpdate())) {
+      data = await cache.getData();
+    } else {
+      var latestUpdate = await OpenData.getLastUpdateData();
+      data = await http
+          .read(Uri.parse(URLConst.somministrazioneVacciniSummaryLatest));
+      cache.update(latestUpdate, data);
+    }
+
     List<SomministrazioneVacciniSummaryLatest> list = [];
 
-    if (response.statusCode == 200) {
-      var jsonResponse = convert.jsonDecode(response.body);
-      var jsonData = jsonResponse['data'];
+    var jsonResponse = convert.jsonDecode(data);
+    var jsonData = jsonResponse['data'];
 
-      for (var element in jsonData) {
-        list.add(new SomministrazioneVacciniSummaryLatest(
-          index: element['index'],
-          area: element['area'],
-          data_somministrazione: element['data_somministrazione'],
-          totale: element['totale'],
-          sesso_maschile: element['sesso_maschile'],
-          sesso_femminile: element['sesso_femminile'],
-          categoria_operatori_sanitari_sociosanitari:
-              element['categoria_operatori_sanitari_sociosanitari'],
-          categoria_personale_non_sanitario:
-              element['categoria_personale_non_sanitario'],
-          categoria_ospiti_rsa: element['categoria_ospiti_rsa'],
-          categoria_over80: element['categoria_over80'],
-          prima_dose: element['prima_dose'],
-          seconda_dose: element['seconda_dose'],
-          nome_regione: element['nome_area'],
-        ));
-      }
+    for (var element in jsonData) {
+      list.add(new SomministrazioneVacciniSummaryLatest(
+        index: element['index'],
+        area: element['area'],
+        data_somministrazione: element['data_somministrazione'],
+        totale: element['totale'],
+        sesso_maschile: element['sesso_maschile'],
+        sesso_femminile: element['sesso_femminile'],
+        categoria_operatori_sanitari_sociosanitari:
+            element['categoria_operatori_sanitari_sociosanitari'],
+        categoria_personale_non_sanitario:
+            element['categoria_personale_non_sanitario'],
+        categoria_ospiti_rsa: element['categoria_ospiti_rsa'],
+        categoria_over80: element['categoria_over80'],
+        prima_dose: element['prima_dose'],
+        seconda_dose: element['seconda_dose'],
+        nome_regione: element['nome_area'],
+      ));
     }
     return list;
   }

--- a/lib/Screens/components/body_components.dart
+++ b/lib/Screens/components/body_components.dart
@@ -1,4 +1,3 @@
-import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:statusvaccini/constants/constant.dart';
@@ -119,9 +118,8 @@ Column buildTopBarRegioni(Size size, String title, BuildContext context) {
                 ),
                 Container(
                   alignment: Alignment.bottomCenter,
-                  child: AutoSizeText(
+                  child: Text(
                     title,
-                    maxLines: 1,
                     style: TextStyle(
                       fontSize: 24,
                       color: SVConst.textColor,

--- a/lib/Screens/components/pageitems/region_details_items.dart
+++ b/lib/Screens/components/pageitems/region_details_items.dart
@@ -4,7 +4,7 @@ import 'package:statusvaccini/Models/opendata.dart';
 import 'package:statusvaccini/Screens/components/cards/regioni_somministrazioni_summary.dart';
 import 'package:statusvaccini/Screens/components/cards/somministrazioni_regione.dart';
 import 'package:statusvaccini/Screens/components/graphs/graph_multiple_linear_card.dart';
-import 'package:statusvaccini/screens/components/graphs/graph_linear_ultime_consegne.dart';
+import 'package:statusvaccini/Screens/components/graphs/graph_linear_ultime_consegne.dart';
 
 class RegionDetailsItems {
   Widget card;

--- a/lib/Screens/views/region_details.dart
+++ b/lib/Screens/views/region_details.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:statusvaccini/Models/opendata.dart';
 import 'package:statusvaccini/Screens/components/pageitems/region_details_items.dart';
-import 'package:statusvaccini/screens/components/body_components.dart';
+import 'package:statusvaccini/Screens/components/body_components.dart';
 
 class RegionDetailsView extends StatelessWidget {
   RegionDetailsView(this.regione);

--- a/lib/cache/cache.dart
+++ b/lib/cache/cache.dart
@@ -1,0 +1,37 @@
+import 'package:path_provider/path_provider.dart';
+import 'package:statusvaccini/Models/opendata.dart';
+import 'dart:io' show File;
+
+const latestUpdateFileName = "latest_update.txt";
+
+class Cache<T> {
+  // al momento l'unica cosa che fa il tipo è salvare tipi diversi in file diversi
+  String filename = T.toString(); // dovrebbe essere il nome del tipo
+  Future<bool> needsUpdate() async {
+    File file = File(
+        '${(await getApplicationDocumentsDirectory()).path}/$filename.txt');
+    if (!(await file.exists())) return true;
+    var remoteDate = await OpenData.getLastUpdateData();
+    var content = int.parse(await file.readAsString());
+    if (content != remoteDate.millisecondsSinceEpoch)
+      return true;
+    else
+      return false;
+  }
+
+  Future<void> update(DateTime latestUpdate, String data) async {
+    File updateFile = File(
+        '${(await getApplicationDocumentsDirectory()).path}/$filename.txt');
+    File dataFile = File(
+        '${(await getApplicationDocumentsDirectory()).path}/$filename.json');
+    await dataFile.writeAsString(data);
+    await updateFile.writeAsString("${latestUpdate.millisecondsSinceEpoch}");
+  }
+
+  Future<String> getData() async {
+    File file = File(
+        '${(await getApplicationDocumentsDirectory()).path}/$filename.json');
+
+    return await file.readAsString();
+  }
+}


### PR DESCRIPTION
Cache su file degli open data, non ho avuto modo di testare il tutto estensivamente ma l'idea è che quando si aggiornano gli open data dovrebbe aggiornare anche la cache.

Com'è fatto ora si fanno tante richieste al dato dell'ultimo aggiornamento ma è per garantire che ci siano meno problemi possibile se aggiornano gli open data mentre l'utente li sta consultando.

Con qualche piccola modifica si potrebbe far funzionare l'app anche completamente offline con i dati scaricati in precedenza dall'utente quando la connessione ad internet non è disponibile.